### PR TITLE
Desktop: add Feed category

### DIFF
--- a/data/leopod.desktop.in
+++ b/data/leopod.desktop.in
@@ -2,7 +2,7 @@
 Name=Leopod
 GenericName=Podcast Client App
 Comment=Organize and listen to your podcasts
-Categories=Audio;AudioVideo;Network;
+Categories=Audio;AudioVideo;Feed;Network;
 Exec=com.github.leggettc18.leopod
 Icon=com.github.leggettc18.leopod
 Terminal=false


### PR DESCRIPTION
According to https://specifications.freedesktop.org/menu-spec/latest/apas02.html this category should be used for Podcast players