### PR TITLE
Update the runtime to elementary os 6.1

### DIFF
--- a/com.github.leggettc18.leopod.yml
+++ b/com.github.leggettc18.leopod.yml
@@ -2,7 +2,7 @@
 app-id: com.github.leggettc18.leopod
 
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '6.1'
 sdk: io.elementary.Sdk
 
 command: com.github.leggettc18.leopod


### PR DESCRIPTION
Updates the flatpak runtime to Elementary OS 6.1. No further work was needed to make the app work with this runtime, so this is a small pull request.