### PR TITLE
Fixes infinite loading screen on first launch

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -95,6 +95,9 @@ public class Application : Gtk.Application {
             });
         });
         window.playback_box.hide ();
+        if (controller.first_run) {
+            window.switch_visible_page (window.welcome);
+        }
         window.present ();
 
         // Add short delay, just long enough for the window to

--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -88,6 +88,7 @@ namespace Leopod {
 
         public async void post_creation_sequence () {
             if (first_run) {
+                app.window.on_loaded ();
                 app.window.switch_visible_page (app.window.welcome);
             } else {
                 yield app.library.refill_library ();

--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -88,7 +88,6 @@ namespace Leopod {
 
         public async void post_creation_sequence () {
             if (first_run) {
-                app.window.on_loaded ();
                 app.window.switch_visible_page (app.window.welcome);
             } else {
                 yield app.library.refill_library ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -222,7 +222,11 @@ public class MainWindow : Gtk.ApplicationWindow {
         notebook.add_titled (welcome, "welcome", _("Welcome"));
         notebook.add_titled (episodes_scrolled, "podcast-episodes", _("Episodes"));
 
-        main_layout.attach (loading_box, 0, 1);
+        if (app.controller.first_run) {
+            main_layout.attach (notebook, 0, 1);
+        } else {
+            main_layout.attach (loading_box, 0, 1);
+        }
 
         double playback_rate = app.settings.playback_rate;
         app.player.rate = playback_rate;


### PR DESCRIPTION
I accidentally introduced a bug that causes a loading screen to be displayed infinitely on the very first launch. This fixes that.