### PR TITLE
Fixes Deprecation Warnings

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -75,11 +75,6 @@ public class Application : Gtk.Application {
 
         var provider = new Gtk.CssProvider ();
         provider.load_from_resource ("/com/github/leggettc18/leopod/application.css");
-        Gtk.StyleContext.add_provider_for_display (
-          Gdk.Display.get_default (),
-          provider,
-          Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        );
 
         settings = LeopodSettings.get_default_instance ();
         download_manager = new DownloadManager ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -75,6 +75,11 @@ public class Application : Gtk.Application {
 
         var provider = new Gtk.CssProvider ();
         provider.load_from_resource ("/com/github/leggettc18/leopod/application.css");
+        Gtk.StyleContext.add_provider_for_display (
+          Gdk.Display.get_default (),
+          provider,
+          Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
 
         settings = LeopodSettings.get_default_instance ();
         download_manager = new DownloadManager ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -362,7 +362,7 @@ public class MainWindow : Gtk.ApplicationWindow {
             back_button = new Gtk.Button () {
                 label = back_text,
             };
-            back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
+            back_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
             back_button.clicked.connect (() => {
                 header_bar.remove (back_button);
                 switch_visible_page (back_widget);

--- a/src/Widgets/AddPodcastDialog.vala
+++ b/src/Widgets/AddPodcastDialog.vala
@@ -41,7 +41,7 @@ namespace Leopod {
             // Add buttons to button area at the bottom
             add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
             this.add_podcast_button = add_button (_("Add"), Gtk.ResponseType.ACCEPT);
-            this.add_podcast_button.get_style_context ().add_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
+            this.add_podcast_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
             this.add_podcast_button.sensitive = false;
 
             podcast_uri_entry.changed.connect (() => {

--- a/src/Widgets/CoverArt.vala
+++ b/src/Widgets/CoverArt.vala
@@ -17,8 +17,8 @@ namespace Leopod {
             orientation = Gtk.Orientation.VERTICAL;
             var controller = new Gtk.GestureClick ();
             controller.released.connect ((num_presses, x, y) => {
-                    clicked (this.podcast);
-                    });
+                clicked (this.podcast);
+            });
             add_controller (controller);
             image = new Gtk.Image () {
                 margin_top = margin_end = margin_start = margin_bottom = 2,
@@ -27,7 +27,7 @@ namespace Leopod {
             Gtk.Button button = new Gtk.Button () {
                 tooltip_text = _("Browse Podcast Episodes"),
             };
-            button.get_style_context ().add_class ("coverart");
+            button.add_css_class ("coverart");
 
             //Load the actual coverart
             info (podcast.local_art_uri);

--- a/src/Widgets/DownloadDetailBox.vala
+++ b/src/Widgets/DownloadDetailBox.vala
@@ -110,7 +110,7 @@ public class DownloadDetailBox : Gtk.Box {
         ) {
             tooltip_text = _("Cancel Download")
         };
-        cancel_button.get_style_context ().add_class ("flat");
+        cancel_button.add_css_class (Granite.STYLE_CLASS_FLAT);
         cancel_button.tooltip_text = _("Cancel Download");
         cancel_button.clicked.connect (() => {
             download.cancel ();

--- a/src/Widgets/EpisodeListItem.vala
+++ b/src/Widgets/EpisodeListItem.vala
@@ -128,7 +128,7 @@ namespace Leopod {
                 tooltip_text = _("Description"),
                 hexpand = true,
                 has_frame = true,
-                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION }
+                css_classes = { "episode-button" }
             };
 
             info_button.clicked.connect (() => {
@@ -142,7 +142,7 @@ namespace Leopod {
                 hexpand = true,
                 tooltip_text = _("Download"),
                 has_frame = true,
-                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION },
+                css_classes = { "episode-button" },
             };
 
             download_button.clicked.connect (() => {
@@ -161,7 +161,7 @@ namespace Leopod {
                 tooltip_text = _("Play"),
                 hexpand = true,
                 has_frame = true,
-                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION },
+                css_classes = { "episode-button" },
             };
             play_button.clicked.connect (() => {
                 play_requested (episode);
@@ -173,7 +173,7 @@ namespace Leopod {
                 tooltip_text = _("Delete"),
                 hexpand = true,
                 has_frame = true,
-                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION },
+                css_classes = { "episode-button" },
             };
 
             delete_button.clicked.connect (() => {

--- a/src/Widgets/EpisodeListItem.vala
+++ b/src/Widgets/EpisodeListItem.vala
@@ -73,7 +73,7 @@ namespace Leopod {
                 max_width_chars = 30,
                 ellipsize = Pango.EllipsizeMode.END
             };
-            title.get_style_context ().add_class ("h3");
+            title.add_css_class ("h3");
             desc_text = Utils.html_to_markup (episode.description);
 
             try {
@@ -128,7 +128,7 @@ namespace Leopod {
                 tooltip_text = _("Description"),
                 hexpand = true,
                 has_frame = true,
-                css_classes = { "episode-button" }
+                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION }
             };
 
             info_button.clicked.connect (() => {
@@ -142,7 +142,7 @@ namespace Leopod {
                 hexpand = true,
                 tooltip_text = _("Download"),
                 has_frame = true,
-                css_classes = { "episode-button" },
+                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION },
             };
 
             download_button.clicked.connect (() => {
@@ -161,7 +161,7 @@ namespace Leopod {
                 tooltip_text = _("Play"),
                 hexpand = true,
                 has_frame = true,
-                css_classes = { "episode-button" },
+                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION },
             };
             play_button.clicked.connect (() => {
                 play_requested (episode);
@@ -173,7 +173,7 @@ namespace Leopod {
                 tooltip_text = _("Delete"),
                 hexpand = true,
                 has_frame = true,
-                css_classes = { "episode-button" },
+                css_classes = { Granite.STYLE_CLASS_SUGGESTED_ACTION },
             };
 
             delete_button.clicked.connect (() => {

--- a/src/Widgets/PlaybackBox.vala
+++ b/src/Widgets/PlaybackBox.vala
@@ -45,20 +45,19 @@ public class PlaybackBox : Gtk.Box {
         );
 
         artwork_image.tooltip_text = _("View the shownotes for this episode");
-        artwork_image.margin_bottom = artwork_image.margin_top =
         artwork_image.margin_start = artwork_image.margin_end = 12;
+        margin_top = margin_bottom = 12;
         artwork_image.halign = Gtk.Align.START;
 
         episode_label = new Gtk.Label ("");
         episode_label.set_ellipsize (Pango.EllipsizeMode.END);
         episode_label.xalign = 0.0f;
-        episode_label.get_style_context ().add_class ("h3");
-        episode_label.max_width_chars = 20;
+        episode_label.max_width_chars = 30;
 
         podcast_label = new Gtk.Label ("");
         podcast_label.set_ellipsize (Pango.EllipsizeMode.END);
         podcast_label.xalign = 0.0f;
-        podcast_label.max_width_chars = 20;
+        podcast_label.max_width_chars = 30;
 
         playback_rate_popover = new PlaybackRatePopover (app.settings.playback_rate);
         playback_rate_popover.rate_selected.connect ((t, r) => {

--- a/src/Windows/DownloadsWindow.vala
+++ b/src/Windows/DownloadsWindow.vala
@@ -68,7 +68,7 @@ public class DownloadsWindow : Gtk.Window {
         box.append (listbox);
 
         downloads_complete = new Gtk.Label (_("No Active Downloads"));
-        downloads_complete.get_style_context ().add_class ("h3");
+        downloads_complete.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
         downloads_complete.sensitive = false;
         //downloads_complete.margin = 12;
         box.prepend (downloads_complete);


### PR DESCRIPTION
Switches to Gtk.FileDialogs, and removes remaining calls to `get_style_context`. There is still a warning about `Gtk.StyleContext`, but that's because I'm using `add_provider_for_display`, which is [apparently not deprecated](https://discourse.gnome.org/t/what-good-is-gtkcssprovider-without-gtkstylecontext/12621).